### PR TITLE
 Potions BAM and PLAT98

### DIFF
--- a/1pp/components/113_switch.tph
+++ b/1pp/components/113_switch.tph
@@ -59,7 +59,7 @@ ACTION_IF (is_bg2 OR is_tob OR is_tutu) BEGIN // GAME_IS ~bg2 tob tutu tutu_tots
 	SILENT
 	COPY_EXISTING_REGEXP GLOB ~^.+\.itm$~ ~override~
 		READ_SHORT 0x1c "itemtype" ELSE 0
-		PATCH_IF (itemtype = 2) BEGIN
+		PATCH_IF (itemtype = 2) AND ("%SOURCE_RES%" STRING_COMPARE_CASE ~PLAT98~) BEGIN
 			READ_ASCII 0x22 "anim" (2)
 			PATCH_IF (("%anim%" STRING_COMPARE_CASE "2w" = 0) OR
 					  ("%anim%" STRING_COMPARE_CASE "3w" = 0) OR

--- a/1pp/components/200_1ppv2_cut.tph
+++ b/1pp/components/200_1ppv2_cut.tph
@@ -974,11 +974,17 @@ COPY ~1pp/item/v2_copy/sw1hwk.itm~		~override~
  *          POTIONS          *
  * ========================= */
 
-ACTION_IF (1pp_potions_icons = 2) BEGIN
+ACTION_IF (1pp_potions_icons = 1) BEGIN
 	PRINT @200001 // ~Copying...~
 	SILENT
 	COPY ~1pp/item/v2_copy/ipotn52.bam~ ~override~
+	COPY_EXISTING ~potn52.itm~ ~override~
+	  WRITE_ASCII 0x58 ~cpotn02~ #8
+	BUT_ONLY
 	COPY ~1pp/item/v2_copy/ipotn55.bam~ ~override~
+	COPY_EXISTING ~potn55.itm~ ~override~
+	  WRITE_ASCII 0x58 ~cpotn41~ #8
+	BUT_ONLY
 END
 
 


### PR DESCRIPTION
- component 200 : Core content patches update inventory's bam of potion without updating description's bam + fix a regression of v4.2.0
- Component 113 : Smart Avatar & Armour Switching should not update PLAT98 to stay faithful to BG1 phoenix guard (it is a mage animation for pheoarch.cre)